### PR TITLE
Fix code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/pkg/verifierlog/verifierlog.go
+++ b/pkg/verifierlog/verifierlog.go
@@ -1137,12 +1137,12 @@ func (spl *SubProgLocation) verifierStmt() {}
 func parsePropagatePrecision(line string) VerifierStatement {
 	line = strings.TrimPrefix(line, "propagating ")
 	if strings.HasPrefix(line, "r") {
-		regInt, err := strconv.Atoi(strings.TrimPrefix(line, "r"))
+		regUint, err := strconv.ParseUint(strings.TrimPrefix(line, "r"), 10, 8)
 		if err != nil {
-			return &Error{Msg: fmt.Sprintf("register number atoi: %s", err)}
+			return &Error{Msg: fmt.Sprintf("register number parse uint: %s", err)}
 		}
 
-		reg := asm.Register(regInt)
+		reg := asm.Register(regUint)
 		return &PropagatePrecision{
 			Register: &reg,
 		}


### PR DESCRIPTION
### **User description**
Fixes [https://github.com/khulnasoft/coverbee/security/code-scanning/12](https://github.com/khulnasoft/coverbee/security/code-scanning/12)

To fix the problem, we need to ensure that the value parsed from the string is within the valid range for the `asm.Register` type before performing the conversion. This can be achieved by using `strconv.ParseUint` with a specified bit size and then checking the bounds before converting to `asm.Register`.

1. Replace the use of `strconv.Atoi` with `strconv.ParseUint` to specify the bit size.
2. Add bounds checking to ensure the parsed value is within the valid range for `asm.Register` (0 to 255).
3. If the value is out of bounds, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incorrect conversion between integer types by replacing strconv.Atoi with strconv.ParseUint and adding bounds checking for asm.Register.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect conversion between integer types in `parsePropagatePrecision` by replacing `strconv.Atoi` with `strconv.ParseUint`.
- Added bounds checking for register numbers by specifying a bit size of 8.
- Updated error handling to reflect the use of `ParseUint`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verifierlog.go</strong><dd><code>Fix integer conversion and add bounds checking in </code><br><code><code>parsePropagatePrecision</code></code></dd></summary>
<hr>

pkg/verifierlog/verifierlog.go

<li>Replaced <code>strconv.Atoi</code> with <code>strconv.ParseUint</code> for parsing register <br>numbers.<br> <li> Added bounds checking by specifying a bit size of 8.<br> <li> Updated error message to reflect the use of <code>ParseUint</code>.<br> <li> Converted parsed value to <code>asm.Register</code> using <code>uint</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/coverbee/pull/12/files#diff-aa4a605d01f4f4e271ad6989511a4a1663a617195cae1c24edc341ba2543e55b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information